### PR TITLE
Fix NoMethodError on list_neighborhoods with subdistrict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#38](https://github.com/sarslanoglu/turkish_cities/issues/38): ```NoMethodError``` on ```list_neighborhoods``` when called with wrong subdistrict name
+
+### Changes
+
+* [#39](https://github.com/sarslanoglu/turkish_cities/issues/39): May maintenance of gem - 2020-05-24
 
 ## 0.2.0 (2020-05-18)
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ TurkishCities.list_neighborhoods('Istanbul', 'Beşiktaş', 'Gayrettepe')
 # => ["Balmumcu Mah", "Dikilitaş Mah", "Gayrettepe Mah", "Yıldız Mah"]
 TurkishCities.list_neighborhoods('Adana', 'Beşiktaş', 'Emek')
 # => "Couldn't find district name with 'Beşiktaş' of 'Adana'"
+TurkishCities.list_neighborhoods('Eskişehir', 'Odunpazarı', 'Büyükkkkkdere')
+# => "Couldn't find subdistrict with 'Büyükkkkkdere' of 'Odunpazarı'/'Eskişehir'"
 ```
 
 ### Without subdistrict info

--- a/lib/turkish_cities/district.rb
+++ b/lib/turkish_cities/district.rb
@@ -26,20 +26,28 @@ class District
     district_list = create_district_list(city_name)
 
     if !district_list[district_name].nil?
-      neighborhoods = if subdistrict_name.nil?
-                        create_neighborhoods_without_subdistrict_name(district_list, district_name)
-                      else
-                        create_neighborhoods_with_subdistrict_name(district_list,
-                                                                   district_name,
-                                                                   subdistrict_name)
-                      end
-      sort_alphabetically(neighborhoods)
+      neighborhoods = create_neighborhoods(district_list, city_name,
+                                           district_name, subdistrict_name)
+
+      neighborhoods.is_a?(Array) ? sort_alphabetically(neighborhoods) : neighborhoods
     else
       district_not_found_error(district_name, city_name)
     end
   end
 
   private
+
+  def create_neighborhoods(district_list, city_name, district_name, subdistrict_name)
+    if subdistrict_name.nil?
+      create_neighborhoods_without_subdistrict_name(district_list, district_name)
+    else
+      if district_list[district_name][subdistrict_name].nil?
+        return subdistrict_not_found_error(subdistrict_name, district_name, city_name)
+      end
+
+      create_neighborhoods_with_subdistrict_name(district_list, district_name, subdistrict_name)
+    end
+  end
 
   def create_neighborhoods_without_subdistrict_name(district_list, district_name)
     neighborhoods = []

--- a/lib/turkish_cities/helpers/decomposer_helper.rb
+++ b/lib/turkish_cities/helpers/decomposer_helper.rb
@@ -70,6 +70,10 @@ module DecomposerHelper
     end
   end
 
+  def subdistrict_not_found_error(subdistrict_input, district_input, city_input)
+    "Couldn't find subdistrict with '#{subdistrict_input}' of '#{district_input}'/'#{city_input}'"
+  end
+
   private
 
   def add_plate_number_if_requested(result, city, options = nil)

--- a/spec/turkish_cities_spec.rb
+++ b/spec/turkish_cities_spec.rb
@@ -268,6 +268,8 @@ RSpec.describe TurkishCities do
           .to eq "Couldn't find district name with 'Beşiktaş' of 'filansehir'"
         expect(TurkishCities.list_neighborhoods('İstanbul', 'filanmevki'))
           .to eq "Couldn't find district name with 'filanmevki' of 'İstanbul'"
+        expect(TurkishCities.list_neighborhoods('Eskişehir', 'Odunpazarı', 'Büyükkkkkdere'))
+          .to eq "Couldn't find subdistrict with 'Büyükkkkkdere' of 'Odunpazarı'/'Eskişehir'"
       end
     end
   end


### PR DESCRIPTION
### Related github issue for this PR

Resolves #38 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation `README.md`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [x] `rubocop` gives no error locally
* [x] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### Description

TurkishCities.list_neighborhoods('Eskişehir', 'Odunpazarı', 'Büyükkkkkdere') method was given NoMethodError (undefined method `[]' for nil:NilClass)

It needs to be clear that user has send wrong parameters to method

With this change it returns ```"Couldn't find subdistrict with 'Büyükkkkkdere' of 'Odunpazarı'/'Eskişehir'"```

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### Which tests are written for this PR? And what are the expected results for these tests?

One test added to
```
describe '#list_neighborhoods' do
  context 'when input is not supported' do
    it 'gives city_not_found_error' do
```
