### PR TITLE
Fix no implicit conversion of Array into String error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## master
+
+### Bug fixes
+
+* [#113](https://github.com/sarslanoglu/turkish_cities/issues/113): Fix no implicit conversion of Array into String error
+
 ## 0.6.0 (2022-02-26)
 
 ### New features

--- a/lib/turkish_cities.rb
+++ b/lib/turkish_cities.rb
@@ -9,7 +9,8 @@ require_relative '../lib/turkish_cities/version'
 
 require 'i18n'
 
-I18n.load_path << Dir["#{File.expand_path('config/locales')}/*.yml"]
+I18n.load_path << "#{File.expand_path('config/locales')}/en.yml"
+I18n.load_path << "#{File.expand_path('config/locales')}/tr.yml"
 
 class TurkishCities
   PLATE_NUMBER = 'plate_number'


### PR DESCRIPTION
### Related github issue for this PR

Resolves #113 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation `README.md`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [x] `rubocop` gives no error locally

### Description

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What changed, and why?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

Include anything else we should know about. -->

File include was expecting a string while code was providing array with two elements. In order to eliminate the problem I changed array type to string type at I18n file include

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
